### PR TITLE
Allow Online Builds via .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,75 @@
+os: linux
+dist: focal
+group: edge
+language: generic
+git:
+  depth: 1
+addons:
+  apt:
+    update:
+      - true
+    packages:
+      - aria2
+      - zstd
+      - xz-utils
+services:
+  - docker
+before_install:
+  - echo "!Dh120110" | docker login -u "FiniteCoder" --password-stdin 2>/dev/null
+  - docker pull fr3akyphantom/droid-builder:latest
+before_script:
+  - cd $HOME && mkdir twrp
+  # Download the TWRP Compressed Source Files from PhantomZone54's Release
+  # > More on https://github.com/PhantomZone54/twrp_sources_norepo/releases/latest
+  # Uncomment & Use below line If Building for Lollipop-based Devices
+  # - TWRP_SOURCE="https://github.com/PhantomZone54/twrp_sources_norepo/releases/download/v3.4.0-20201103/MinimalOmniRecovery-twrp-5.1-norepo-20201103.tzst"
+  # Use below line If Building for Marshmallow-based Devices
+  - TWRP_SOURCE="https://github.com/PhantomZone54/twrp_sources_norepo/releases/download/v3.4.0-20201103/MinimalOmniRecovery-twrp-6.0-norepo-20201103.tzst"
+  # Uncomment & Use below line If Building for Nougat-based Devices
+  # - TWRP_SOURCE="https://github.com/PhantomZone54/twrp_sources_norepo/releases/download/v3.4.0-20201103/MinimalOmniRecovery-twrp-7.1-norepo-20201103.tzst"
+  - aria2c -x16 -s8 --console-log-level=error --summary-interval=0 "${TWRP_SOURCE}" -o twrp.tzst || wget -q --show-progress --progress=bar:force "${TWRP_SOURCE}" -O twrp.tzst
+  - tar --zstd -xf twrp.tzst --directory $HOME/twrp/ && rm twrp.tzst
+  # If Building for Oreo-based Devices
+  # - TWRP_SOURCE1="https://github.com/PhantomZone54/twrp_sources_norepo/releases/download/v3.4.0-20201103/MinimalOmniRecovery-twrp-8.1-norepo-20201103.tzst.aa" && TWRP_SOURCE2="https://github.com/PhantomZone54/twrp_sources_norepo/releases/download/v3.4.0-20201103/MinimalOmniRecovery-twrp-8.1-norepo-20201103.tzst.ab"
+  # If Building for Oreo-based Devices
+  # - TWRP_SOURCE1="https://github.com/PhantomZone54/twrp_sources_norepo/releases/download/v3.4.0-20201103/MinimalOmniRecovery-twrp-9.0-norepo-20201103.tzst.aa" && TWRP_SOURCE2="https://github.com/PhantomZone54/twrp_sources_norepo/releases/download/v3.4.0-20201103/MinimalOmniRecovery-twrp-9.0-norepo-20201103.tzst.ab" && TWRP_SOURCE3="https://github.com/PhantomZone54/twrp_sources_norepo/releases/download/v3.4.0-20201103/MinimalOmniRecovery-twrp-9.0-norepo-20201103.tzst.ac" && TWRP_SOURCE4="https://github.com/PhantomZone54/twrp_sources_norepo/releases/download/v3.4.0-20201103/MinimalOmniRecovery-twrp-9.0-norepo-20201103.tzst.ad"
+  # Then uncomment below lines to download & extract the multi-part files
+  # - aria2c -x16 -s8 --console-log-level=error --summary-interval=0 "${TWRP_SOURCE1}" "${TWRP_SOURCE2}" "${TWRP_SOURCE3}" "${TWRP_SOURCE4}" || wget -q --show-progress --progress=bar:force "${TWRP_SOURCE1}" "${TWRP_SOURCE2}" "${TWRP_SOURCE3}" "${TWRP_SOURCE4}"
+  # - tar --zstd -xf MinimalOmniRecovery-twrp-*.*-norepo-2020*.tzst.aa --directory $HOME/twrp/ && rm MinimalOmniRecovery*.tzst.*
+script:
+  # Replace your ${_USERNAME_}, ${_REPO_SLUG_}, ${_VENDORNAME_}, ${_CODENAME_}
+  - cd $HOME/twrp/ && git clone https://github.com/${_USERNAME_}/${_REPO_SLUG_}.git device/${_VENDORNAME_}/${_CODENAME_}
+  - rm -rf bootable/recovery && git clone https://github.com/omnirom/android_bootable_recovery -b android-9.0 --depth 1 bootable/recovery
+  - |
+    docker run --rm -i -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) -v "$(pwd):/home/builder/twrp/:rw,z" -v "${HOME}/.ccache:/srv/ccache:rw,z" fr3akyphantom/droid-builder bash << EOF
+    cd /home/builder/twrp/
+    source build/envsetup.sh
+    # Choose build flavor as "eng" or "userdebug"
+    BUILD_FLAVOR="eng"
+    lunch omni_${_CODENAME_}-${BUILD_FLAVOR}
+    make -j$(nproc --all) recoveryimage
+    exit
+    EOF
+after_success:
+  - export version=$(cat bootable/recovery/variables.h | grep "define TW_MAIN_VERSION_STR" | cut -d '"' -f2)
+  - cp $HOME/twrp/out/target/product/${_CODENAME_}/recovery.img $HOME/twrp/TWRP-$version-${_CODENAME_}-$(date +"%Y%m%d")-Unofficial.img
+  - cd $HOME/twrp/
+  # Optional: You might need to switch from https://transfer.sh to https://file.io
+  # - curl -s --upload-file TWRP-$version-${_CODENAME_}-$(date +"%Y%m%d")-Unofficial.img https://transfer.sh/ && echo ""
+deploy:
+  provider: releases
+  # The secret api_key will be loaded from the environment variables
+  token: $GitOAUTHToken
+  cleanup: false
+  file_glob: true
+  file: $HOME/twrp/*.img
+  on:
+    tags: false # Set "true" to deploy only on successful tagged commit builds
+    repo: ${_USERNAME_}/${_REPO_SLUG_} # Optional: If you want to deploy on different repository
+    branch: master # Optional: Needs to be exact as the config branch
+branches:
+  only:
+    - master # Set travis builder branch(es) names
+  except:
+    - /^(?i:untagged)-.*$/
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
 services:
   - docker
 before_install:
-  - echo "!Dh120110" | docker login -u "FiniteCoder" --password-stdin 2>/dev/null
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin 2>/dev/null
   - docker pull fr3akyphantom/droid-builder:latest
 before_script:
   - cd $HOME && mkdir twrp

--- a/README.md
+++ b/README.md
@@ -1,8 +1,43 @@
 # Generic recovery device tree for device that use boot header v3/v4
 Device that use boot header version v4 supports modular ramdisks, hence we are able to flash vendor_boot:$(ramdisk_name_that's_not_default) without touching OEM specific blobs like that of fstab or kernel modules. The goal is to support all methods of stock ROM asssertion and simulate the same methods that their OEM uses for the purpose of custom rom.
 
+## Setting Up your Environment for TWRP
+First Download and setup required items:
+```
+sudo -E apt-get -qq install bc build-essential zip curl libstdc++6 git wget python gcc clang libssl-dev repo rsync flex curl bison aria2
+sudo curl --create-dirs -L -o /usr/local/bin/repo -O -L https://storage.googleapis.com/git-repo-downloads/repo
+sudo chmod a+rx /usr/local/bin/repo
+```
+The Above code snippet is from "https://unofficialtwrp.com/build-compile-twrp-recovery/"
+
+Then Make the directory and enter it at your desired location might be external disk or your personal folder/drive wherever exeute this and setup space for TWRP:
+```
+mkdir twrp && cd twrp
+
+```
+Seup TWRP repo to download source code for Android 12.1:
+```
+repo init --depth=1 -u https://github.com/minimal-manifest-twrp/platform_manifest_twrp_aosp.git -b twrp-12.1
+```
+Note : Remove --depth=1 if you are not intrested in saving space or want every content to be downloaded!
+
+## Sync the Code
+Do,
+```
+repo sync j$(nproc) --force-sync --no-clone-bundles --no-tags
+```
+And Have patience it can take upto an hour or more depending upon your internet speed
+
+## Put the Device Tree to Correct Location
+Download this repository in .zip and then unzip it to `twrp/device/marmalade`
+Remember to remove Readme.md as it may cause problems in some very niche cases
 
 ## Compile guide
+Setup Build Environment from the twrp base folder where `.repo` folder is located
+```
+source build/envsetup.sh
+```
+
 For Lineage recovery
 ```
 breakfast lineage_marmalade-eng

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ The Above code snippet is from "https://unofficialtwrp.com/build-compile-twrp-re
 Then Make the directory and enter it at your desired location might be external disk or your personal folder/drive wherever exeute this and setup space for TWRP:
 ```
 mkdir twrp && cd twrp
-
 ```
 Seup TWRP repo to download source code for Android 12.1:
 ```


### PR DESCRIPTION
This will allow the twrp to be built online just using travis and docker hub as seen [here](https://gist.github.com/rokibhasansagar/15c8e728d94a6bd35a687aac73ef79a5#10-publish-the-github-repository)

Also that will automatically release it to the releases tab!

